### PR TITLE
Update image credit text to be accessible

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -127,6 +127,7 @@ a.nav-link:active, a.foot-link:active {color: var(--white);}
   padding: 0 5px;
   position: absolute;
   right: 30px;
+  z-index: 10000;
 }
 #splash-top {
   height: 100%;


### PR DESCRIPTION
I updated the image credit text to have the same z-index as the overlay. This way it sits on top of the overlay and is A11y compliant.